### PR TITLE
wip(ios): add moon task to publish Android SDK

### DIFF
--- a/libraries/android/moon.yml
+++ b/libraries/android/moon.yml
@@ -1,0 +1,10 @@
+type: 'library'
+language: 'kotlin'
+
+workspace:
+  inheritedTasks:
+    exclude: ['build']
+
+tasks:
+  publish:
+    command: './gradlew publishToMavenCentral --no-configuration-cache'


### PR DESCRIPTION
Recently we setup publishing to Android SDK to Maven Central. This pull request creates a moon task to more easily do so.